### PR TITLE
[patch] accept valid IANA timezone aliases in fullDateShape

### DIFF
--- a/packages/date-vir/src/full-date/full-date-shape.ts
+++ b/packages/date-vir/src/full-date/full-date-shape.ts
@@ -12,9 +12,10 @@ import {
     type MonthNumber,
     type Second,
 } from '@date-vir/duration';
-import {defineShape, enumShape, intersectShape, rangeShape} from 'object-shape-tester';
+import {defineShape, intersectShape, rangeShape} from 'object-shape-tester';
 import {type Simplify} from 'type-fest';
-import {Timezone, utcTimezone} from '../timezone/timezones.js';
+import {timezoneShape} from '../timezone/timezone-shape.js';
+import {type Timezone} from '../timezone/timezones.js';
 
 /**
  * Time part of {@link FullDate} represented in a shape definition.
@@ -43,7 +44,7 @@ export const timePartShape = defineShape({
         default: millisecondsBounds.min,
     }),
     /** The timezone that this date/time is meant for / originated from. */
-    timezone: enumShape(Timezone, utcTimezone),
+    timezone: timezoneShape(),
 });
 
 /**
@@ -79,7 +80,7 @@ export const datePartShape = defineShape({
         default: dayOfMonthBounds.min,
     }),
     /** The timezone that this date/time is meant for / originated from. */
-    timezone: enumShape(Timezone, utcTimezone),
+    timezone: timezoneShape(),
 });
 
 /**

--- a/packages/date-vir/src/full-date/is-valid-full-date.test.ts
+++ b/packages/date-vir/src/full-date/is-valid-full-date.test.ts
@@ -23,8 +23,17 @@ describe(assertValidFullDate.name, () => {
                     timezone: 'not a real timezone' as Timezone,
                 },
                 throws: {
-                    matchMessage: '/timezone: Expected union value',
+                    matchConstructor: ShapeMismatchError,
                 },
+            },
+            {
+                it: 'accepts a legacy IANA timezone alias',
+                input: {
+                    ...fullDateShape.default,
+                    /** Some environments (e.g. Safari) still report this legacy alias from `Intl`. */
+                    timezone: 'America/Indianapolis' as Timezone,
+                },
+                throws: undefined,
             },
             {
                 it: 'rejects a missing timezone object',

--- a/packages/date-vir/src/index.ts
+++ b/packages/date-vir/src/index.ts
@@ -26,6 +26,7 @@ export * from './full-date/maybe-create-date.js';
 export * from './full-date/parsing.js';
 export * from './timezone/timezone-checks.js';
 export * from './timezone/timezone-names.js';
+export * from './timezone/timezone-shape.js';
 export * from './timezone/timezones.js';
 
 export * from '@date-vir/duration';

--- a/packages/date-vir/src/timezone/timezone-shape.test.ts
+++ b/packages/date-vir/src/timezone/timezone-shape.test.ts
@@ -1,0 +1,36 @@
+import {describe, itCases} from '@augment-vir/test';
+import {checkValidShape} from 'object-shape-tester';
+import {timezoneShape} from './timezone-shape.js';
+
+describe('timezoneShape', () => {
+    itCases(
+        (value: unknown) => checkValidShape(value, timezoneShape()),
+        [
+            {
+                it: 'accepts a canonical timezone name',
+                input: 'Australia/Melbourne',
+                expect: true,
+            },
+            {
+                it: 'accepts utc',
+                input: 'UTC',
+                expect: true,
+            },
+            {
+                it: 'accepts a legacy IANA alias not in the typed list',
+                input: 'America/Indianapolis',
+                expect: true,
+            },
+            {
+                it: 'rejects an invalid timezone string',
+                input: 'not a real timezone',
+                expect: false,
+            },
+            {
+                it: 'rejects a non-string value',
+                input: 5,
+                expect: false,
+            },
+        ],
+    );
+});

--- a/packages/date-vir/src/timezone/timezone-shape.ts
+++ b/packages/date-vir/src/timezone/timezone-shape.ts
@@ -1,0 +1,22 @@
+import {check} from '@augment-vir/assert';
+import {createCustomShape} from 'object-shape-tester';
+import {isValidTimezone} from './timezone-checks.js';
+import {type Timezone, utcTimezone} from './timezones.js';
+
+/**
+ * A shape for a {@link Timezone} value.
+ *
+ * Unlike a strict enum check against the typed {@link Timezone} list, this validates at runtime via
+ * {@link isValidTimezone} (i.e. any valid IANA zone name). It therefore accepts valid IANA names
+ * that aren't in the typed list, such as legacy aliases like `'America/Indianapolis'` that some
+ * environments (notably Safari) still report from `Intl`. The static type remains {@link Timezone}.
+ *
+ * @category Shape
+ */
+export const timezoneShape = createCustomShape<Timezone>({
+    default: utcTimezone,
+    name: 'Timezone',
+    checkValue(value): value is Timezone {
+        return check.isString(value) && isValidTimezone(value);
+    },
+});


### PR DESCRIPTION
From @nelsons502:

fullDateShape validated `timezone` with enumShape(Timezone), which only accepts names in the hardcoded allTimezoneNames list. But parseLuxonDateTime stamps whatever zone Luxon reports, and some environments (notably Safari) report legacy IANA aliases like America/Indianapolis that aren't in that list. date-vir would then produce a FullDate that isValidFullDate later rejects, throwing `Failed to parse date input` (e.g. on render of a relative/absolute time component).

Align the shape's runtime validation with assertValidTimezone/isValidTimezone (valid IANA zone) via a new timezoneShape, while keeping the static Timezone type.